### PR TITLE
Adds functionality to check leaderboard for other users

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -4,12 +4,14 @@ pairs:
     rl: Ryan Langren
     ja: James Artz
     ac: Adam Casey
+    ff: Frank Fiorante
 email_addresses:
     mw: designed4device@gmail.com
     hr: heather0809@gmail.com
     rl: rklandgren@gmail.com
     ja: jelliotartz@gmail.com
     ac: caseyadamj@gmail.com
+    ff: fiorantefrank@gmail.com
 email:
     prefix: pair
     domain: holyguacamole.io

--- a/src/main/kotlin/io/holyguacamole/bot/message/ContentCrafter.kt
+++ b/src/main/kotlin/io/holyguacamole/bot/message/ContentCrafter.kt
@@ -42,12 +42,14 @@ You can give avocados to anyone on your team. I am always watching, so you don't
 """`/invite $BOT_NAME`: to invite me to a channel
 `$BOT_NAME help`: to see helpful resources and information
 `$BOT_NAME leaderboard [number]`: to show the leaderboard, eg. leaderboard 20, defaults to top 10
+`$BOT_NAME leaderboard [@userId]`: to show another users position in the leaderboard
 `$BOT_NAME leaderboard me`: to show your position in the leaderboard"""
 
     const val HELP_DM_TITLE = "Direct Message Commands"
     const val HELP_DM_TEXT =
 """`help`: to see helpful resources and information
 `leaderboard [number]`: to show the leaderboard, eg. leaderboard 20, defaults to top 10
+`leaderboard [@userId]`: to show another users position in the leaderboard
 `leaderboard me`: to show your position in the leaderboard
 `avocados`: to see how many avocados you have left to give out today"""
 

--- a/src/main/kotlin/io/holyguacamole/bot/message/EventService.kt
+++ b/src/main/kotlin/io/holyguacamole/bot/message/EventService.kt
@@ -81,6 +81,10 @@ class EventService(
                     channel = event.channel,
                     text = craftMyLeaderboardMessage(repository.getLeaderboard(0), event.user?: "user not found")
                 )
+                text.contains(Regex("$LEADERBOARD_COMMAND <@([0-9a-zA-Z]*?)>")) -> slackClient.postMessage(
+                        channel = event.channel,
+                        text = craftMyLeaderboardMessage(repository.getLeaderboard(0), cleanUserId(text))
+                )
                 text.contains(Regex("$LEADERBOARD_COMMAND \\d*")) -> slackClient.postMessage(
                         channel = event.channel,
                         text = craftLeaderboardMessage(repository.getLeaderboard(
@@ -148,6 +152,10 @@ class EventService(
                 text.contains("$LEADERBOARD_COMMAND me") -> slackClient.postMessage(
                     channel = event.channel,
                     text = craftMyLeaderboardMessage(repository.getLeaderboard(0), event.user)
+                )
+                text.contains(Regex("$LEADERBOARD_COMMAND <@([0-9a-zA-Z]*?)>")) -> slackClient.postMessage(
+                        channel = event.channel,
+                        text = craftMyLeaderboardMessage(repository.getLeaderboard(0), cleanUserId(text))
                 )
                 text.contains(Regex("$LEADERBOARD_COMMAND \\d*")) -> sendLeaderboard(
                         channel = event.channel,
@@ -306,14 +314,15 @@ class EventService(
 
     companion object {
         fun countGuacamoleIngredients(text: String): Int = (text.split(AVOCADO_TEXT).size) - 1
-        fun findMentionedPeople(text: String, user: String): List<String> = Regex("<@([0-9A-Z]*?)>")
+        fun findMentionedPeople(text: String, user: String): List<String> = Regex("<@([0-9A-Za-z]*?)>")
                 .findAll(text)
                 .mapNotNull { it.groups[1]?.value }
                 .filter { it != user }
                 .toList()
-
-
     }
+        fun cleanUserId(text: String): String {
+            return text.split("leaderboard")[1].trim().removePrefix("<").removePrefix("@").removeSuffix(">").toUpperCase()
+        }
 }
 
 fun <T> mapUntil(end: Int, fn: () -> T): List<T> = (0 until end).map { fn() }

--- a/src/main/kotlin/io/holyguacamole/bot/message/EventService.kt
+++ b/src/main/kotlin/io/holyguacamole/bot/message/EventService.kt
@@ -321,7 +321,7 @@ class EventService(
                 .toList()
     }
         fun cleanUserId(text: String): String {
-            return text.split("leaderboard")[1].trim().removePrefix("<").removePrefix("@").removeSuffix(">").toUpperCase()
+            return text.split("leaderboard")[1].trim().substringAfter("@").substringBefore(">").toUpperCase()
         }
 }
 

--- a/src/test/kotlin/io/holyguacamole/bot/MockObjects.kt
+++ b/src/test/kotlin/io/holyguacamole/bot/MockObjects.kt
@@ -570,6 +570,22 @@ object MockAppMentions {
         eventId = "12345679",
         eventTime = 1234567890
     )
+    val leaderboardOtherUser = EventCallback(
+            token = token,
+            teamId = "abc",
+            apiAppId = "123",
+            event = MessageEvent(
+                    type = APP_MENTION,
+                    channel = general,
+                    user = patrick,
+                    text = "<@$appbot> leaderboard <@$mark>",
+                    ts = today
+            ),
+            type = EVENT_CALLBACK,
+            authedUsers = listOf(appbot),
+            eventId = "12345679",
+            eventTime = 1234567890
+    )
     val help = EventCallback(
             token = token,
             teamId = "abc",

--- a/src/test/kotlin/io/holyguacamole/bot/message/EventServiceTest.kt
+++ b/src/test/kotlin/io/holyguacamole/bot/message/EventServiceTest.kt
@@ -293,6 +293,30 @@ class EventServiceTest {
     }
 
     @Test
+    fun `it checks for the 'leaderboard otherUser' and posts the leaderboard +- 2 from the user to slack`() {
+        whenever(repository.getLeaderboard(0)).thenReturn(listOf(
+                AvocadoCount(ryan, 12),
+                AvocadoCount(jeremy, 12),
+                AvocadoCount(dwayne, 8),
+                AvocadoCount(mark, 5),
+                AvocadoCount(jeremyp, 4),
+                AvocadoCount(patrick, 3),
+                AvocadoCount(eight, 1)
+        ))
+
+        eventService.process(MockAppMentions.leaderboardOtherUser)
+        verify(slackClient).postMessage(general,
+                """
+                  2. ${jeremyskywalker.name}: 12
+                  3. ${dwaynetheguacjohnson.name}: 8
+                  4. ${markardito.name}: 5
+                  5. ${jeremypiewalker.name}: 4
+                  6. ${feeneyfeeneybobeeney.name}: 3
+                """.trimIndent()
+        )
+    }
+
+    @Test
     fun `it calls the slack client to post the help message`() {
         eventService.process(MockAppMentions.help)
 


### PR DESCRIPTION
This pull request adds the ability to check the leaderboard for other users. You can do so saying to the bot `@holyguacamole leaderboard @SomeOtherSlackUser`. I added a new test case for this functionality also.

